### PR TITLE
docs: Add missing dependencies for `uvx` command

### DIFF
--- a/docs/generate.md
+++ b/docs/generate.md
@@ -15,7 +15,7 @@ copier copy --trust "gh:pawamoy/copier-uv" /path/to/your/new/project
 You can even generate a project without installing Copier, using [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uvx copier copy --trust "gh:pawamoy/copier-uv" /path/to/your/new/project
+uvx --with copier-templates-extensions copier copy --trust "gh:pawamoy/copier-uv" /path/to/your/new/project
 ```
 
 ## Questions


### PR DESCRIPTION
In `docs/generate.md`

```console
$ uvx copier copy --trust "gh:pawamoy/copier-uv" copier-demo
Copier could not load some Jinja extensions:
No module named 'copier_templates_extensions'
Make sure to install these extensions alongside Copier itself.
See the docs at https://copier.readthedocs.io/en/latest/configuring/#jinja_extensions
```

`--with copier-templates-extensions` is missing. I have checked that `uvx` is not used outside of this page.