### PR TITLE
feat: split dependency-groups in sections

### DIFF
--- a/docs/work.md
+++ b/docs/work.md
@@ -91,7 +91,7 @@ Use `make setup` or `uv sync` to install the dependencies.
 
 Dependencies are written in `pyproject.toml`.
 Runtime dependencies are listed under the `[project]` and `[project.optional-dependencies]` sections,
-and development dependencies are listed under the `[tool.uv]` section.
+and development dependencies are listed under the `[dependency-groups]` section.
 
 Example:
 
@@ -107,8 +107,8 @@ test = [
   "pytest",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+ci = [
   "ruff",
 ]
 ```

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -77,13 +77,12 @@ data = [
 ]
 
 [dependency-groups]
-dev = [
-    # maintenance
+maintain = [
     "build>=1.2",
     "git-changelog>=2.5",
     "twine>=5.1",
-
-    # ci
+]
+ci = [
     "duty>=1.4",
     "ruff>=0.4",
     "pytest>=8.2",
@@ -93,8 +92,8 @@ dev = [
     "mypy>=1.10",
     "types-markdown>=3.6",
     "types-pyyaml>=6.0",
-
-    # docs
+]
+ docs = [
     "markdown-callouts>=0.4",
     "markdown-exec>=1.8",
     "mkdocs>=1.6",
@@ -110,3 +109,7 @@ dev = [
     # YORE: EOL 3.10: Remove line.
     "tomli>=2.0; python_version < '3.11'",
 ]
+
+[tool.uv]
+# Add all dependency-groups as default
+default-groups = ["maintain","ci","docs"]

--- a/project/scripts/gen_credits.py.jinja
+++ b/project/scripts/gen_credits.py.jinja
@@ -27,7 +27,7 @@ with project_dir.joinpath("pyproject.toml").open("rb") as pyproject_file:
     pyproject = tomllib.load(pyproject_file)
 project = pyproject["project"]
 project_name = project["name"]
-devdeps = [dep for dep in pyproject["dependency-groups"]["dev"] if not dep.startswith("-e")]
+devdeps = [dep for group in pyproject["dependency-groups"].values() for dep in group if not dep.startswith("-e")]
 
 PackageMetadata = dict[str, Union[str, Iterable[str]]]
 Metadata = dict[str, PackageMetadata]


### PR DESCRIPTION
# Change
This implements [development-dependencies as groups](https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies), to enable using only part of the dependencies, e.g. for deploy or ci.

For this we add  the groups `maintain`, `ci` and `docs` are added. Documentation is adapted as needed.

# Open Question
Think if you want to keep these names. For `uv` the default name is `dev` and there is a [flag for this name](https://docs.astral.sh/uv/reference/cli/#uv-add--dev). 

Options:
- One could rename the `maintain` or `ci` group to `dev`. 
- Maybe it is an option to combine `ci` and `maintain` to `dev`.

Things to consider: 
- What usecases are there, where only part of the dependencies are needed? I can think of: docs deployment, running ci-tests, release-pipeline, ...

Reference - Question #58 