### PR TITLE
fix: upon creating a new project CLI script fails to startup due to cli module not found

### DIFF
--- a/project/duties.py.jinja
+++ b/project/duties.py.jinja
@@ -35,7 +35,7 @@ def pyprefix(title: str) -> str:
 def _get_changelog_version() -> str:
     changelog_version_re = re.compile(r"^## \[(\d+\.\d+\.\d+)\].*$")
     with Path(__file__).parent.joinpath("CHANGELOG.md").open("r", encoding="utf8") as file:
-        return next(filter(bool, map(changelog_version_re.match, file))).group(1)  # ty: ignore[invalid-argument-type]
+        return next(filter(bool, map(changelog_version_re.match, file))).group(1)  # ty: ignore[unresolved-attribute]
 
 
 @duty

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -44,7 +44,7 @@ Funding = "https://{{ repository_provider }}/sponsors/{{ author_username }}"
 
 {% if python_package_command_line_name -%}
 [project.scripts]
-{{ python_package_command_line_name }} = "{{ python_package_import_name }}.cli:main"
+{{ python_package_command_line_name }} = "{{ python_package_import_name }}:main"
 
 {% endif -%}
 

--- a/project/scripts/get_version.py.jinja
+++ b/project/scripts/get_version.py.jinja
@@ -22,7 +22,7 @@ def get_version() -> str:
     if scm_version.version <= Version("0.1"):  # Missing Git tags?
         with suppress(OSError, StopIteration):  # noqa: SIM117
             with _changelog.open("r", encoding="utf8") as file:
-                match = next(filter(None, map(_changelog_version_re.match, file)))  # ty: ignore[invalid-argument-type]
+                match = next(filter(None, map(_changelog_version_re.match, file)))
                 scm_version = scm_version._replace(version=Version(match.group(1)))
     return default_version_formatter(scm_version)
 


### PR DESCRIPTION
I noticed I needed to modify the pyproject.toml of a new  to generate a CLI startup script that works.  

Details available in #84 
 
I note that the CI pipeline fails to compile `copier` for python 3.15, where tests pass for older versions.